### PR TITLE
[AI] 노션 기반 블로그/링크드인 초안 자동화 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,47 @@
+NOTION_API_KEY=secret_xxx
+
+# Default draft mode is `codex`, which never uses the OpenAI API key even if one exists.
+# Set this to `openai` only if you explicitly want direct API draft generation.
+BLOG_DRAFT_MODE=codex
+
+# Optional: only needed if `BLOG_DRAFT_MODE=openai`.
+# If this is empty, the script will pull the Notion source and write
+# `output/create-blog-codex-prompt.md` for a Codex session to finish the draft.
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-5
+
+# Source: database mode
+NOTION_DATA_SOURCE_ID=
+NOTION_DATABASE_ID=
+
+# Source: page tree mode
+NOTION_ROOT_PAGE_ID=
+NOTION_BLOG_SOURCE_PAGE_ID=
+NOTION_LINKEDIN_SOURCE_PAGE_ID=
+NOTION_BLOG_SOURCE_PATH=
+NOTION_LINKEDIN_SOURCE_PATH=
+NOTION_BLOG_TARGET_PAGE_ID=
+NOTION_TREE_LIST_DEPTH=1
+
+# Source schema
+NOTION_STATUS_PROPERTY=status
+NOTION_READY_STATUS_VALUE=Ready
+NOTION_TYPE_PROPERTY=type
+NOTION_PLATFORM_PROPERTY=platform
+
+# Workflow filters
+NOTION_BLOG_TYPE_VALUE=blog
+NOTION_BLOG_PLATFORM_VALUE=
+NOTION_LINKEDIN_TYPE_VALUE=linkedin
+NOTION_LINKEDIN_PLATFORM_VALUE=
+
+# LinkedIn publish target: choose one
+NOTION_LINKEDIN_TARGET_PAGE_ID=
+NOTION_LINKEDIN_TARGET_DATABASE_ID=
+
+# Optional target database properties
+NOTION_LINKEDIN_TARGET_STATUS_PROPERTY=
+NOTION_LINKEDIN_TARGET_STATUS_VALUE=
+
+# Optional title suffix for published page
+NOTION_LINKEDIN_TITLE_SUFFIX= - LinkedIn

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.env
+output/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,132 @@
 # blog-automation
+
+Notion source notes -> blog draft / LinkedIn draft workflow for Codex.
+
+## What this repo does
+
+- Pull a source page from Notion by URL, page id, page path, or database filter.
+- Save normalized source artifacts into `output/`.
+- Draft a Tistory-style Markdown blog post.
+- Optionally publish the final draft under another Notion page.
+
+## Environment
+
+Copy `.env.example` to `.env`.
+
+Required:
+
+- `NOTION_API_KEY`
+
+Optional:
+
+- `NOTION_ROOT_PAGE_ID`
+- `NOTION_BLOG_SOURCE_PATH`
+- `NOTION_LINKEDIN_SOURCE_PATH`
+- `NOTION_BLOG_TARGET_PAGE_ID`
+- `BLOG_DRAFT_MODE`
+- `OPENAI_API_KEY`
+
+`BLOG_DRAFT_MODE` defaults to `codex`. In this mode, `npm run create-blog` does not call the OpenAI API directly. Instead it uses the locally installed Codex CLI through your ChatGPT login.
+
+Use `BLOG_DRAFT_MODE=openai` only if you explicitly want direct API draft generation.
+
+## Blog workflow
+
+### 1. Pull from a Notion URL
+
+```powershell
+npm run create-blog -- "https://www.notion.so/...."
+```
+
+This always writes:
+
+- `output/create-blog-source.md`
+- `output/create-blog-source.json`
+
+### 2. Draft generation modes
+
+#### API mode
+
+If `BLOG_DRAFT_MODE=openai` and `OPENAI_API_KEY` is configured, the same command also writes:
+
+- `output/create-blog.md`
+
+If `NOTION_BLOG_TARGET_PAGE_ID` is configured, it also publishes the draft under that Notion page.
+
+#### Codex mode
+
+If `BLOG_DRAFT_MODE=codex` the command:
+
+1. pulls the Notion source
+2. writes `output/create-blog-source.*`
+3. runs `codex exec` non-interactively
+4. writes `output/create-blog.md`
+5. publishes to Notion when `NOTION_BLOG_TARGET_PAGE_ID` is configured
+
+It also writes:
+
+- `output/create-blog-codex-prompt.md`
+- `output/create-blog-codex-result.txt`
+
+`output/create-blog-codex-prompt.md` is kept as a fallback prompt if the local Codex CLI execution fails.
+
+### 3. Source-only mode
+
+```powershell
+npm run create-blog-source -- "https://www.notion.so/...."
+```
+
+Use this only when you want the pulled source artifacts without draft generation or Codex handoff.
+
+## Page path mode
+
+If you prefer paths instead of URLs:
+
+```powershell
+npm run create-blog -- "tcc.mw/프로젝트/어떤페이지"
+```
+
+To explore available paths:
+
+```powershell
+npm run list-notion-tree
+npm run list-notion-tree -- "tcc.mw/프로젝트"
+```
+
+The tree command is intentionally shallow by default so it does not traverse the entire workspace unless needed.
+
+## LinkedIn workflow
+
+Pull source:
+
+```powershell
+npm run create-linkedin -- "https://www.notion.so/...."
+```
+
+Publish the generated LinkedIn draft to another Notion page or database:
+
+```powershell
+npm run publish-linkedin
+```
+
+## Files
+
+- `scripts/create-blog.js`: blog entrypoint
+- `scripts/create-blog-source.js`: source-only blog pull
+- `scripts/create-linkedin.js`: LinkedIn source pull
+- `scripts/list-notion-tree.js`: page path listing
+- `scripts/publish-blog-draft.js`: publish `output/create-blog.md` into Notion
+- `scripts/publish-linkedin.js`: publish `output/create-linkedin.md` into Notion
+- `templates/tistory-blog-draft.md`: Tistory-style writing template
+- `codex-skills/create-blog`: local skill draft
+
+## Typical commands
+
+```powershell
+npm run create-blog -- "https://www.notion.so/...."
+npm run create-blog -- "tcc.mw/프로젝트/어떤페이지"
+npm run create-blog-source -- "https://www.notion.so/...."
+npm run publish-blog-draft
+npm run create-linkedin -- "https://www.notion.so/...."
+npm run publish-linkedin
+```

--- a/codex-skills/create-blog/SKILL.md
+++ b/codex-skills/create-blog/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: create-blog
+description: Pull a ready source note from Notion and draft a publishable blog post in this repository. Use when the user writes "create-blog", asks to turn a Notion note into a blog article, or wants Codex to draft long-form blog copy from the latest ready Notion entry.
+---
+
+# Create Blog
+
+Run this workflow when the user invokes `create-blog`.
+
+## Goal
+
+Read a selected Notion source note from a Notion URL, page id, page path, or database workflow, turn it into a polished article, save the draft to `output/create-blog.md`, and publish it to a configured Notion draft page when available.
+
+This workflow supports two modes:
+
+- `API mode`: `BLOG_DRAFT_MODE=openai`. `scripts/create-blog.js` pulls the source, generates the draft, and publishes it when `OPENAI_API_KEY` is configured.
+- `Codex mode`: `BLOG_DRAFT_MODE=codex` (default). `scripts/create-blog.js` pulls the source only and writes `output/create-blog-codex-prompt.md`. In this mode, Codex must draft `output/create-blog.md` and then run `scripts/publish-blog-draft.js` when publishing is needed.
+
+## Required Flow
+
+1. Verify that `scripts/create-blog.js` exists in the current repository.
+2. When running inside an interactive Codex session, do not call `scripts/create-blog.js` because it can invoke `codex exec` recursively.
+3. Prefer `node scripts/create-blog-source.js "<notion-url>"` when the user provides a Notion page URL.
+4. Accept `node scripts/create-blog-source.js "<page-id>"` when the user provides a page id.
+5. Accept `node scripts/create-blog-source.js "<path>"` when the user provides a page path.
+6. If the user did not provide a source URL, page id, or path and page-tree mode is configured, run `node scripts/list-notion-tree.js` and choose a path with the user.
+7. Read `output/create-blog-source.md` and `output/create-blog-source.json`.
+8. Read `templates/tistory-blog-draft.md` and follow it when drafting the final article.
+9. Draft a blog post from the pulled source without inventing facts that are not in the note.
+10. Save the final article to `output/create-blog.md`.
+11. If `NOTION_BLOG_TARGET_PAGE_ID` is configured, run `node scripts/publish-blog-draft.js` after writing the draft.
+12. Report the source title, source page id, source path if used, draft output path, and published page URL when present.
+
+## Writing Rules
+
+- Default to Korean unless the source note clearly targets another language.
+- Preserve the original argument, examples, and factual claims.
+- Improve structure, transitions, headline wording, and conclusion as needed.
+- If the source note is missing a critical fact, call out the gap instead of guessing.
+
+## Preferred Article Pattern
+
+Follow the article shape extracted from the user's preferred example.
+
+1. Start with a short problem hook:
+   - Introduce the topic simply.
+   - Explain why frontend or practical developers should care.
+   - Name the pain point before introducing the solution.
+2. Explain the existing concept or common approach first:
+   - Example: explain the spread operator before introducing Immer.
+   - Show why the common approach becomes hard to read or maintain.
+3. Introduce the main tool or concept as the solution:
+   - Use a natural, slightly conversational section title when it fits.
+   - Example patterns: `{개념}?`, `{도구}? 넌 누구냐`, `왜 이게 필요한가`
+4. Explain the working principle:
+   - Break down the internal mechanism in plain language.
+   - If a function or key concept exists, explain it separately.
+5. Explain how to use it:
+   - Installation
+   - Basic usage
+   - Real-world or framework example
+6. Add caution points:
+   - Mention practical pitfalls in a short dedicated section.
+7. Close with a recommendation:
+   - Reinforce when and why the tool is worth using.
+
+## Style Pattern
+
+- Write like a technical blog post, not like notes pasted as-is.
+- Keep the tone soft and explanatory.
+- Use natural connectors such as `개발을 하다 보면`, `쉽게 말하면`, and `정리하면`.
+- When the source is about a library, API, or framework feature, prefer this narrative:
+  - what problem appears in practice
+  - why the existing way is awkward
+  - what the new tool solves
+  - how it works
+  - how to use it
+  - what to watch out for
+- After showing a code block, briefly explain what the reader should notice in that code.
+- Favor section headings that are readable and slightly conversational over dry textbook headings when it fits the topic.
+
+## Safety Rules
+
+- Do not modify the pulled source artifacts except by re-running the pull script.
+- If the Notion script fails, report the missing environment variable or schema mismatch directly.
+- Keep generated files inside `output/`.

--- a/codex-skills/create-blog/agents/openai.yaml
+++ b/codex-skills/create-blog/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Create Blog
+short_description: Pull a ready Notion note and draft a publishable blog post.
+default_prompt: create-blog

--- a/codex-skills/create-linkedin/SKILL.md
+++ b/codex-skills/create-linkedin/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: create-linkedin
+description: Pull a ready source note from Notion, draft a LinkedIn-ready summary in a fixed structure, and optionally publish that result into another Notion page. Use when the user writes "create-linkedin", asks to turn a Notion note into a LinkedIn post, or wants Codex to organize a source note into a target Notion page.
+---
+
+# Create LinkedIn
+
+Run this workflow when the user invokes `create-linkedin`.
+
+## Goal
+
+Read a selected Notion source note from a Notion URL, page id, page path, or database workflow, draft a consistent LinkedIn package, save it to `output/create-linkedin.md`, and publish it into a target Notion page when target credentials are configured.
+
+## Required Flow
+
+1. Verify that `scripts/create-linkedin.js` exists in the current repository.
+2. Prefer `node scripts/create-linkedin.js "<notion-url>"` when the user provides a Notion page URL.
+3. Accept `node scripts/create-linkedin.js "<page-id>"` when the user provides a page id.
+4. Accept `node scripts/create-linkedin.js "<path>"` when the user provides a page path.
+5. If the user did not provide a source URL, page id, or path and page-tree mode is configured, run `node scripts/list-notion-tree.js` and choose a path with the user.
+6. Read `output/create-linkedin-source.md` and `output/create-linkedin-source.json`.
+7. Draft the final content in this structure:
+   - `# {title}`
+   - `## Hook`
+   - `## LinkedIn Post`
+   - `## Key Points`
+   - `## CTA`
+8. Save the final markdown to `output/create-linkedin.md`.
+9. If `NOTION_LINKEDIN_TARGET_PAGE_ID` or `NOTION_LINKEDIN_TARGET_DATABASE_ID` is configured, run `node scripts/publish-linkedin.js`.
+10. Report the source page, source path if used, local output path, and published page URL if one was created.
+
+## Writing Rules
+
+- Default to Korean unless the source note clearly targets another language.
+- Keep the LinkedIn post concise enough to publish directly.
+- Preserve factual claims from the source note and tighten phrasing for scanability.
+- Use `Key Points` for short bullets, not dense prose.
+
+## Safety Rules
+
+- Do not publish anything until `output/create-linkedin.md` exists and has been reviewed in the current turn.
+- If the target Notion page or database is not configured, stop after saving the markdown draft and report the missing target variable.
+- Keep generated files inside `output/`.

--- a/codex-skills/create-linkedin/agents/openai.yaml
+++ b/codex-skills/create-linkedin/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Create LinkedIn
+short_description: Pull a ready Notion note, draft a LinkedIn package, and publish it to Notion.
+default_prompt: create-linkedin

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "blog-automation",
+  "version": "1.0.0",
+  "description": "Codex + Notion workflows for blog and LinkedIn drafting.",
+  "main": "index.js",
+  "scripts": {
+    "create-blog": "node scripts/create-blog.js",
+    "create-blog-source": "node scripts/create-blog-source.js",
+    "create-linkedin": "node scripts/create-linkedin.js",
+    "create-linkedin-source": "node scripts/create-linkedin.js",
+    "list-notion-tree": "node scripts/list-notion-tree.js",
+    "publish-blog-draft": "node scripts/publish-blog-draft.js",
+    "publish-linkedin": "node scripts/publish-linkedin.js",
+    "check": "node --check scripts/create-blog.js && node --check scripts/create-blog-source.js && node --check scripts/create-linkedin.js && node --check scripts/list-notion-tree.js && node --check scripts/publish-blog-draft.js && node --check scripts/publish-linkedin.js && node --check scripts/lib/load-env.js && node --check scripts/lib/notion-api.js && node --check scripts/lib/notion-render.js && node --check scripts/lib/notion-workflows.js && node --check scripts/lib/openai-api.js && node --check scripts/lib/parse-source-input.js && node --check scripts/lib/publish-blog-draft.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/scripts/create-blog-source.js
+++ b/scripts/create-blog-source.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+const { loadLocalEnv } = require("./lib/load-env");
+
+loadLocalEnv();
+
+const { parseSourceInput } = require("./lib/parse-source-input");
+const { pullWorkflowSource, writeWorkflowArtifacts } = require("./lib/notion-workflows");
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});
+
+async function main() {
+  const sourceInput = process.argv.slice(2).join(" ").trim();
+  const result = await pullWorkflowSource("blog", parseSourceInput(sourceInput));
+  const paths = await writeWorkflowArtifacts(result);
+
+  console.log(`Saved "${result.metadata.sourceTitle}" source to ${paths.markdownPath}`);
+}

--- a/scripts/create-blog.js
+++ b/scripts/create-blog.js
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+
+const fs = require("fs/promises");
+const path = require("path");
+const { spawn } = require("child_process");
+const { loadLocalEnv } = require("./lib/load-env");
+
+loadLocalEnv();
+
+const { generateMarkdownDraft } = require("./lib/openai-api");
+const { parseSourceInput } = require("./lib/parse-source-input");
+const { publishBlogDraft } = require("./lib/publish-blog-draft");
+const { pullWorkflowSource, writeWorkflowArtifacts } = require("./lib/notion-workflows");
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});
+
+async function main() {
+  const workspaceRoot = path.resolve(__dirname, "..");
+  const sourceInput = process.argv.slice(2).join(" ").trim();
+  const result = await pullWorkflowSource("blog", parseSourceInput(sourceInput));
+  const paths = await writeWorkflowArtifacts(result);
+  const draftPath = path.join(workspaceRoot, "output", "create-blog.md");
+  const handoffPath = path.join(workspaceRoot, "output", "create-blog-codex-prompt.md");
+  const codexResultPath = path.join(workspaceRoot, "output", "create-blog-codex-result.txt");
+  const codexLogPath = path.join(workspaceRoot, "output", "create-blog-codex.log");
+  const draftMode = getDraftMode();
+
+  console.log(`Saved "${result.metadata.sourceTitle}" source to ${paths.markdownPath}`);
+
+  if (!shouldUseOpenAI()) {
+    await writeCodexHandoff({
+      handoffPath,
+      draftPath,
+      result,
+      paths,
+      workspaceRoot,
+    });
+    if (draftMode === "openai" && !hasOpenAIKey()) {
+      console.log("BLOG_DRAFT_MODE=openai was requested, but OPENAI_API_KEY is not configured. Falling back to Codex.");
+    } else {
+      console.log("Generating draft with Codex CLI.");
+    }
+    console.log(`Saved Codex handoff prompt to ${handoffPath}`);
+
+    await runCodexDraft({
+      workspaceRoot,
+      result,
+      paths,
+      draftPath,
+      codexResultPath,
+      codexLogPath,
+    });
+
+    await assertFileExists(draftPath, "Codex finished but did not write output/create-blog.md.");
+    console.log(`Saved blog draft to ${draftPath}`);
+    console.log(`Saved Codex run log to ${codexLogPath}`);
+
+    let published = null;
+
+    if (process.env.NOTION_BLOG_TARGET_PAGE_ID) {
+      published = await publishBlogDraft({
+        targetInput: process.env.NOTION_BLOG_TARGET_PAGE_ID,
+        inputPath: draftPath,
+        sourceMetaPath: paths.metadataPath,
+        workspaceRoot,
+      });
+    }
+
+    if (published) {
+      console.log(`Published blog draft page to ${published.url || published.pageId}`);
+    }
+
+    return;
+  }
+
+  const instructions = await fs.readFile(
+    path.join(workspaceRoot, "templates", "tistory-blog-draft.md"),
+    "utf8",
+  );
+  const draft = await generateMarkdownDraft({
+    instructions: `${instructions}\n\nReturn only the final Markdown article. Do not wrap it in code fences.`,
+    sourceMarkdown: result.markdown,
+    sourceMeta: result.metadata,
+  });
+
+  await fs.mkdir(path.dirname(draftPath), { recursive: true });
+  await fs.writeFile(draftPath, draft.markdown, "utf8");
+
+  let published = null;
+
+  if (process.env.NOTION_BLOG_TARGET_PAGE_ID) {
+    published = await publishBlogDraft({
+      targetInput: process.env.NOTION_BLOG_TARGET_PAGE_ID,
+      inputPath: draftPath,
+      sourceMetaPath: paths.metadataPath,
+      workspaceRoot,
+    });
+  }
+
+  console.log(`Saved blog draft to ${draftPath}`);
+
+  if (published) {
+    console.log(`Published blog draft page to ${published.url || published.pageId}`);
+  }
+}
+
+function hasOpenAIKey(env = process.env) {
+  return Boolean(String(env.OPENAI_API_KEY || "").trim());
+}
+
+function getDraftMode(env = process.env) {
+  return String(env.BLOG_DRAFT_MODE || "codex").trim().toLowerCase() === "openai" ? "openai" : "codex";
+}
+
+function shouldUseOpenAI(env = process.env) {
+  return getDraftMode(env) === "openai" && hasOpenAIKey(env);
+}
+
+async function writeCodexHandoff({ handoffPath, draftPath, result, paths, workspaceRoot }) {
+  const templatePath = path.join(workspaceRoot, "templates", "tistory-blog-draft.md");
+  const content = [
+    "# Create Blog Codex Handoff",
+    "",
+    "OpenAI API generation is disabled for this workspace.",
+    "Use the current Codex session to turn the pulled Notion source into the final draft.",
+    "",
+    "## Source",
+    `- Title: ${result.metadata.sourceTitle || "Untitled"}`,
+    `- Page ID: ${result.metadata.sourceId || ""}`,
+    `- URL: ${result.metadata.sourceUrl || ""}`,
+    `- Source markdown: ${paths.markdownPath}`,
+    `- Source metadata: ${paths.metadataPath}`,
+    `- Writing template: ${templatePath}`,
+    `- Output draft: ${draftPath}`,
+    "",
+    "## Codex Prompt",
+    "Use the `create-blog` skill or ask Codex to:",
+    "1. Read the source markdown and metadata.",
+    "2. Follow the Tistory draft template.",
+    "3. Write the final article to `output/create-blog.md`.",
+    "4. If `NOTION_BLOG_TARGET_PAGE_ID` is configured, run `npm run publish-blog-draft` after writing the draft.",
+    "",
+    "Suggested prompt:",
+    "",
+    "```text",
+    "create-blog",
+    "```",
+    "",
+  ].join("\n");
+
+  await fs.mkdir(path.dirname(handoffPath), { recursive: true });
+  await fs.writeFile(handoffPath, content, "utf8");
+}
+
+async function runCodexDraft({ workspaceRoot, result, paths, draftPath, codexResultPath, codexLogPath }) {
+  const prompt = buildCodexPrompt({ result, paths, draftPath });
+
+  await fs.mkdir(path.dirname(codexResultPath), { recursive: true });
+  await fs.mkdir(path.dirname(codexLogPath), { recursive: true });
+
+  await new Promise((resolve, reject) => {
+    const stdoutChunks = [];
+    const stderrChunks = [];
+    const child = spawn(
+      "codex",
+      [
+        "exec",
+        "--full-auto",
+        "--cd",
+        workspaceRoot,
+        "--output-last-message",
+        codexResultPath,
+        "--color",
+        "never",
+        "-",
+      ],
+      {
+        cwd: workspaceRoot,
+        stdio: ["pipe", "pipe", "pipe"],
+        env: process.env,
+        shell: process.platform === "win32",
+      },
+    );
+
+    child.stdout.on("data", (chunk) => stdoutChunks.push(Buffer.from(chunk)));
+    child.stderr.on("data", (chunk) => stderrChunks.push(Buffer.from(chunk)));
+
+    child.on("error", (error) => {
+      writeCodexLog(codexLogPath, stdoutChunks, stderrChunks)
+        .catch(() => {})
+        .finally(() => {
+          reject(
+            new Error(
+              `Failed to start Codex CLI. Check 'codex login status' and PATH configuration. ${error.message}`,
+            ),
+          );
+        });
+    });
+
+    child.on("exit", (code) => {
+      writeCodexLog(codexLogPath, stdoutChunks, stderrChunks)
+        .catch(() => {})
+        .finally(() => {
+          if (code === 0) {
+            resolve();
+            return;
+          }
+
+          reject(
+            new Error(
+              `Codex CLI draft generation failed with exit code ${code}. Review ${codexLogPath} and ${codexResultPath}, or rerun 'codex login status'.`,
+            ),
+          );
+        });
+    });
+
+    child.stdin.write(prompt);
+    child.stdin.end();
+  });
+}
+
+async function writeCodexLog(logPath, stdoutChunks, stderrChunks) {
+  const stdout = Buffer.concat(stdoutChunks).toString("utf8");
+  const stderr = Buffer.concat(stderrChunks).toString("utf8");
+  const content = [
+    "# Codex stdout",
+    stdout.trim(),
+    "",
+    "# Codex stderr",
+    stderr.trim(),
+    "",
+  ].join("\n");
+
+  await fs.writeFile(logPath, content, "utf8");
+}
+
+function buildCodexPrompt({ result, paths, draftPath }) {
+  const lines = [
+    "You are drafting a Korean Tistory-ready technical blog post inside this repository.",
+    `Read the pulled source markdown at: ${paths.markdownPath}`,
+    `Read the source metadata at: ${paths.metadataPath}`,
+    "Read the writing instructions at: templates/tistory-blog-draft.md",
+    `Write the final article to: ${draftPath}`,
+    "Do not modify the source artifact files.",
+    "Preserve the source meaning. Improve only structure, tone, readability, and formatting.",
+    "Output must be Markdown suitable for immediate posting.",
+    "Do not publish to Notion yourself.",
+    "Do not run node scripts/publish-blog-draft.js.",
+    "In your final response, report the draft path only.",
+  ];
+
+  if (result && result.metadata) {
+    lines.push(
+      `Source title: ${result.metadata.sourceTitle || "Untitled"}`,
+      `Source URL: ${result.metadata.sourceUrl || ""}`,
+    );
+  }
+
+  return `${lines.join("\n")}\n`;
+}
+
+async function assertFileExists(filePath, message) {
+  try {
+    await fs.access(filePath);
+  } catch (error) {
+    throw new Error(message);
+  }
+}

--- a/scripts/create-linkedin.js
+++ b/scripts/create-linkedin.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+
+const { loadLocalEnv } = require("./lib/load-env");
+
+loadLocalEnv();
+
+const { parseSourceInput } = require("./lib/parse-source-input");
+const { pullWorkflowSource, writeWorkflowArtifacts } = require("./lib/notion-workflows");
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});
+
+async function main() {
+  const sourceInput = process.argv.slice(2).join(" ").trim();
+  const result = await pullWorkflowSource("linkedin", parseSourceInput(sourceInput));
+  const paths = await writeWorkflowArtifacts(result);
+
+  console.log(`Saved "${result.metadata.sourceTitle}" source to ${paths.markdownPath}`);
+}

--- a/scripts/lib/load-env.js
+++ b/scripts/lib/load-env.js
@@ -1,0 +1,50 @@
+const fs = require("fs");
+const path = require("path");
+
+function loadLocalEnv(envPath = path.resolve(__dirname, "..", "..", ".env")) {
+  if (!fs.existsSync(envPath)) {
+    return;
+  }
+
+  const raw = fs.readFileSync(envPath, "utf8");
+
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const separatorIndex = trimmed.indexOf("=");
+
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    const rawValue = trimmed.slice(separatorIndex + 1).trim();
+
+    if (!key || Object.prototype.hasOwnProperty.call(process.env, key)) {
+      continue;
+    }
+
+    process.env[key] = stripWrappingQuotes(rawValue);
+  }
+}
+
+function stripWrappingQuotes(value) {
+  const trimmed = String(value || "").trim();
+
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+
+  return trimmed;
+}
+
+module.exports = {
+  loadLocalEnv,
+};

--- a/scripts/lib/notion-api.js
+++ b/scripts/lib/notion-api.js
@@ -1,0 +1,351 @@
+const https = require("https");
+
+function getNotionConfig(env = process.env) {
+  const notionToken = env.NOTION_API_KEY || env.NOTION_TOKEN;
+  const sourceId = env.NOTION_DATA_SOURCE_ID || env.NOTION_DATABASE_ID;
+  const sourceKind = env.NOTION_DATA_SOURCE_ID
+    ? "data_source"
+    : env.NOTION_DATABASE_ID
+      ? "database"
+      : null;
+  const notionVersion =
+    env.NOTION_VERSION || (sourceKind === "data_source" ? "2025-09-03" : "2022-06-28");
+
+  return {
+    notionToken,
+    sourceId,
+    sourceKind,
+    notionVersion,
+  };
+}
+
+function validateSourceConfig(config) {
+  validateToken(config);
+
+  if (!config.sourceKind || !config.sourceId) {
+    throw new Error("Missing NOTION_DATA_SOURCE_ID or NOTION_DATABASE_ID.");
+  }
+}
+
+function validateToken(config) {
+  if (!config || !config.notionToken) {
+    throw new Error("Missing NOTION_API_KEY (or NOTION_TOKEN).");
+  }
+}
+
+async function fetchSourceSchema(config) {
+  const resourcePath =
+    config.sourceKind === "data_source"
+      ? `/v1/data_sources/${config.sourceId}`
+      : `/v1/databases/${config.sourceId}`;
+
+  return notionRequest(config, {
+    method: "GET",
+    resourcePath,
+  });
+}
+
+async function querySourcePages(config, body) {
+  const resourcePath =
+    config.sourceKind === "data_source"
+      ? `/v1/data_sources/${config.sourceId}/query`
+      : `/v1/databases/${config.sourceId}/query`;
+
+  return notionRequest(config, {
+    method: "POST",
+    resourcePath,
+    body,
+  });
+}
+
+async function fetchDatabaseSchema(config, databaseId) {
+  return notionRequest(config, {
+    method: "GET",
+    resourcePath: `/v1/databases/${databaseId}`,
+  });
+}
+
+async function fetchPage(config, pageId) {
+  return notionRequest(config, {
+    method: "GET",
+    resourcePath: `/v1/pages/${pageId}`,
+  });
+}
+
+async function searchPages(config, body = {}) {
+  return notionRequest(config, {
+    method: "POST",
+    resourcePath: "/v1/search",
+    body: {
+      filter: {
+        property: "object",
+        value: "page",
+      },
+      page_size: 100,
+      ...body,
+    },
+  });
+}
+
+async function fetchAllAccessiblePages(config) {
+  const pages = [];
+  let nextCursor = null;
+
+  do {
+    const response = await searchPages(config, nextCursor ? { start_cursor: nextCursor } : {});
+    pages.push(...(response.results || []).filter((item) => item.object === "page"));
+    nextCursor = response.has_more ? response.next_cursor : null;
+  } while (nextCursor);
+
+  return pages;
+}
+
+async function fetchBlockTree(config, blockId) {
+  const blocks = await fetchBlockChildren(config, blockId);
+
+  for (const block of blocks) {
+    if (block.has_children) {
+      block.children = await fetchBlockTree(config, block.id);
+    }
+  }
+
+  return blocks;
+}
+
+async function fetchBlockChildren(config, blockId) {
+  const blocks = [];
+  let nextCursor = null;
+
+  do {
+    const query = new URLSearchParams({ page_size: "100" });
+
+    if (nextCursor) {
+      query.set("start_cursor", nextCursor);
+    }
+
+    const response = await notionRequest(config, {
+      method: "GET",
+      resourcePath: `/v1/blocks/${blockId}/children?${query.toString()}`,
+    });
+
+    blocks.push(...(response.results || []));
+    nextCursor = response.has_more ? response.next_cursor : null;
+  } while (nextCursor);
+
+  return blocks;
+}
+
+async function createPage(config, payload) {
+  return notionRequest(config, {
+    method: "POST",
+    resourcePath: "/v1/pages",
+    body: payload,
+  });
+}
+
+async function appendBlockChildren(config, blockId, children) {
+  return notionRequest(config, {
+    method: "PATCH",
+    resourcePath: `/v1/blocks/${blockId}/children`,
+    body: { children },
+  });
+}
+
+function buildPropertyFilter(properties, logicalName, expectedValue) {
+  if (expectedValue === undefined || expectedValue === null || String(expectedValue).trim() === "") {
+    return null;
+  }
+
+  const property = findProperty(properties, logicalName);
+
+  if (!property) {
+    const available = Object.keys(properties || {}).join(", ");
+    throw new Error(`Could not find "${logicalName}" property in Notion source. Available: ${available}`);
+  }
+
+  const propertyId = property.id || property.name;
+
+  switch (property.type) {
+    case "status":
+      return { property: propertyId, status: { equals: expectedValue } };
+    case "select":
+      return { property: propertyId, select: { equals: expectedValue } };
+    case "multi_select":
+      return { property: propertyId, multi_select: { contains: expectedValue } };
+    case "rich_text":
+      return { property: propertyId, rich_text: { equals: expectedValue } };
+    case "title":
+      return { property: propertyId, title: { equals: expectedValue } };
+    case "checkbox":
+      return {
+        property: propertyId,
+        checkbox: { equals: String(expectedValue).toLowerCase() === "true" },
+      };
+    case "url":
+      return { property: propertyId, url: { equals: expectedValue } };
+    default:
+      throw new Error(
+        `Property "${property.name}" uses unsupported filter type "${property.type}" for this workflow.`,
+      );
+  }
+}
+
+function buildPropertyValue(properties, logicalName, value) {
+  if (value === undefined || value === null || String(value).trim() === "") {
+    return null;
+  }
+
+  const property = findProperty(properties, logicalName);
+
+  if (!property) {
+    const available = Object.keys(properties || {}).join(", ");
+    throw new Error(`Could not find "${logicalName}" property in Notion target. Available: ${available}`);
+  }
+
+  switch (property.type) {
+    case "title":
+      return { title: richTextFromPlainText(value) };
+    case "status":
+      return { status: { name: String(value) } };
+    case "select":
+      return { select: { name: String(value) } };
+    case "multi_select":
+      return {
+        multi_select: String(value)
+          .split(",")
+          .map((item) => item.trim())
+          .filter(Boolean)
+          .map((name) => ({ name })),
+      };
+    case "rich_text":
+      return { rich_text: richTextFromPlainText(value) };
+    case "checkbox":
+      return { checkbox: String(value).toLowerCase() === "true" };
+    case "url":
+      return { url: String(value) };
+    default:
+      throw new Error(
+        `Property "${property.name}" uses unsupported target type "${property.type}" for automated writes.`,
+      );
+  }
+}
+
+function findProperty(properties, logicalName) {
+  const normalizedTarget = normalizeName(logicalName);
+
+  return Object.entries(properties || {})
+    .map(([name, schema]) => ({
+      ...schema,
+      name: schema.name || name,
+    }))
+    .find((property) => normalizeName(property.name) === normalizedTarget);
+}
+
+function findTitlePropertyName(properties) {
+  const match = Object.entries(properties || {}).find(([, property]) => property.type === "title");
+  return match ? match[0] : null;
+}
+
+function normalizeName(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_-]+/g, "");
+}
+
+function richTextFromPlainText(value) {
+  const text = String(value || "");
+
+  if (!text) {
+    return [];
+  }
+
+  const chunks = [];
+
+  for (let index = 0; index < text.length; index += 2000) {
+    chunks.push({
+      type: "text",
+      text: { content: text.slice(index, index + 2000) },
+    });
+  }
+
+  return chunks;
+}
+
+function notionRequest(config, { method, resourcePath, body }) {
+  validateToken(config);
+
+  const requestBody = body ? JSON.stringify(body) : null;
+  const url = new URL(`https://api.notion.com${resourcePath}`);
+
+  return new Promise((resolve, reject) => {
+    const request = https.request(
+      url,
+      {
+        method,
+        headers: {
+          Authorization: `Bearer ${config.notionToken}`,
+          "Notion-Version": config.notionVersion || "2022-06-28",
+          "Content-Type": "application/json",
+          ...(requestBody ? { "Content-Length": Buffer.byteLength(requestBody) } : {}),
+        },
+      },
+      (response) => {
+        const chunks = [];
+
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => {
+          const rawBody = Buffer.concat(chunks).toString("utf8");
+          const json = rawBody ? tryParseJson(rawBody) : {};
+
+          if (response.statusCode >= 200 && response.statusCode < 300) {
+            resolve(json);
+            return;
+          }
+
+          const message =
+            (json && json.message) ||
+            `Notion API request failed with status ${response.statusCode}.`;
+
+          reject(new Error(message));
+        });
+      },
+    );
+
+    request.on("error", reject);
+
+    if (requestBody) {
+      request.write(requestBody);
+    }
+
+    request.end();
+  });
+}
+
+function tryParseJson(value) {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    return { message: value };
+  }
+}
+
+module.exports = {
+  appendBlockChildren,
+  buildPropertyFilter,
+  buildPropertyValue,
+  createPage,
+  fetchAllAccessiblePages,
+  fetchBlockTree,
+  fetchDatabaseSchema,
+  fetchPage,
+  fetchSourceSchema,
+  findProperty,
+  findTitlePropertyName,
+  getNotionConfig,
+  normalizeName,
+  querySourcePages,
+  richTextFromPlainText,
+  validateSourceConfig,
+  validateToken,
+};

--- a/scripts/lib/notion-render.js
+++ b/scripts/lib/notion-render.js
@@ -1,0 +1,512 @@
+function renderDocument(title, blocks) {
+  const body = renderBlocks(blocks).trim();
+
+  if (!body) {
+    return `# ${escapeMarkdownText(title)}`;
+  }
+
+  return [`# ${escapeMarkdownText(title)}`, body].join("\n\n");
+}
+
+function renderBlocks(blocks, depth = 0) {
+  return (blocks || [])
+    .map((block) => renderBlock(block, depth))
+    .filter(Boolean)
+    .join("\n\n")
+    .replace(/\n{3,}/g, "\n\n");
+}
+
+function renderBlock(block, depth) {
+  const data = block[block.type] || {};
+
+  switch (block.type) {
+    case "paragraph":
+      return withTrailingChildren(indentBlock(renderRichText(data.rich_text), depth), block.children, depth);
+    case "heading_1":
+      return withTrailingChildren(indentBlock(`# ${renderRichText(data.rich_text)}`, depth), block.children, depth);
+    case "heading_2":
+      return withTrailingChildren(indentBlock(`## ${renderRichText(data.rich_text)}`, depth), block.children, depth);
+    case "heading_3":
+      return withTrailingChildren(indentBlock(`### ${renderRichText(data.rich_text)}`, depth), block.children, depth);
+    case "bulleted_list_item":
+      return renderListItem("- ", data.rich_text, block.children, depth);
+    case "numbered_list_item":
+      return renderListItem("1. ", data.rich_text, block.children, depth);
+    case "to_do":
+      return renderListItem(data.checked ? "- [x] " : "- [ ] ", data.rich_text, block.children, depth);
+    case "quote":
+      return renderQuotedBlock(data.rich_text, block.children, depth);
+    case "callout":
+      return renderCalloutBlock(data, block.children, depth);
+    case "toggle":
+      return renderToggleBlock(data.rich_text, block.children, depth);
+    case "divider":
+      return indentBlock("---", depth);
+    case "code":
+      return indentBlock(renderCodeBlock(data.rich_text, data.language), depth);
+    case "equation":
+      return indentBlock(`$$\n${data.expression || ""}\n$$`, depth);
+    case "image":
+      return indentBlock(renderImageBlock(data), depth);
+    case "video":
+      return indentBlock(renderMediaLink("Video", data), depth);
+    case "file":
+      return indentBlock(renderMediaLink("File", data), depth);
+    case "pdf":
+      return indentBlock(renderMediaLink("PDF", data), depth);
+    case "bookmark":
+      return indentBlock(renderLinkLikeBlock(data.url, plainText(data.caption) || data.url), depth);
+    case "embed":
+      return indentBlock(renderLinkLikeBlock(data.url, plainText(data.caption) || "Embed"), depth);
+    case "link_preview":
+      return indentBlock(renderLinkLikeBlock(data.url, data.url), depth);
+    case "table":
+      return indentBlock(renderTableBlock(block), depth);
+    case "column_list":
+    case "column":
+    case "synced_block":
+      return renderBlocks(block.children || [], depth);
+    case "child_page":
+      return indentBlock(`## ${escapeMarkdownText(data.title || "Untitled page")}`, depth);
+    case "table_of_contents":
+    case "breadcrumb":
+      return "";
+    default:
+      return withTrailingChildren(
+        indentBlock(renderFallbackBlock(block.type, data.rich_text || data.caption || []), depth),
+        block.children,
+        depth,
+      );
+  }
+}
+
+function renderListItem(prefix, richText, children, depth) {
+  const content = renderRichText(richText).trim();
+  const line = indentBlock(`${prefix}${content}`.trimEnd(), depth);
+  const nested = renderBlocks(children || [], depth + 1).trim();
+
+  return nested ? `${line}\n${nested}` : line;
+}
+
+function renderQuotedBlock(richText, children, depth) {
+  const parts = [renderRichText(richText), renderBlocks(children || [], 0)].filter(Boolean).join("\n\n");
+
+  return indentBlock(prefixLines(parts, "> "), depth);
+}
+
+function renderCalloutBlock(data, children, depth) {
+  const emoji =
+    data.icon && data.icon.type === "emoji" && data.icon.emoji ? `${data.icon.emoji} ` : "";
+  const content = `${emoji}${renderRichText(data.rich_text)}`.trim();
+  const nested = renderBlocks(children || [], 0);
+  const body = [content, nested].filter(Boolean).join("\n\n");
+
+  return indentBlock(prefixLines(body, "> "), depth);
+}
+
+function renderToggleBlock(richText, children, depth) {
+  const summary = renderRichText(richText).trim() || "Details";
+  const nested = renderBlocks(children || [], 0).trim();
+  const body = nested ? `\n\n${nested}\n` : "\n";
+
+  return indentBlock(`<details>\n<summary>${summary}</summary>${body}\n</details>`, depth);
+}
+
+function renderCodeBlock(richText, language) {
+  const code = plainText(richText);
+  const fence = makeFence(code);
+  const normalizedLanguage =
+    language && language !== "plain text" ? language.replace(/\s+/g, "-").toLowerCase() : "";
+
+  return `${fence}${normalizedLanguage}\n${code}\n${fence}`;
+}
+
+function renderImageBlock(data) {
+  const url = getFileUrl(data);
+
+  if (!url) {
+    return "";
+  }
+
+  const caption = plainText(data.caption);
+  const alt = escapeMarkdownText(caption || "image");
+  const image = `![${alt}](${url})`;
+
+  return caption ? `${image}\n\n*${escapeMarkdownText(caption)}*` : image;
+}
+
+function renderMediaLink(defaultLabel, data) {
+  const url = getFileUrl(data);
+
+  if (!url) {
+    return "";
+  }
+
+  const label = plainText(data.caption) || defaultLabel;
+  return renderLinkLikeBlock(url, label);
+}
+
+function renderLinkLikeBlock(url, label) {
+  if (!url) {
+    return "";
+  }
+
+  return `[${escapeMarkdownText(label || url)}](${url})`;
+}
+
+function renderTableBlock(block) {
+  const rows = (block.children || []).filter((child) => child.type === "table_row");
+
+  if (!rows.length) {
+    return "";
+  }
+
+  const hasColumnHeader = Boolean(block.table && block.table.has_column_header);
+  const headerRows = hasColumnHeader ? rows.slice(0, 1) : [];
+  const bodyRows = hasColumnHeader ? rows.slice(1) : rows;
+  const parts = ["<table>"];
+
+  if (headerRows.length) {
+    parts.push("  <thead>");
+    parts.push(renderTableRows(headerRows, "th"));
+    parts.push("  </thead>");
+  }
+
+  parts.push("  <tbody>");
+  parts.push(renderTableRows(bodyRows, "td"));
+  parts.push("  </tbody>");
+  parts.push("</table>");
+
+  return parts.filter(Boolean).join("\n");
+}
+
+function renderTableRows(rows, cellTag) {
+  return rows
+    .map((row) => {
+      const cells = (row.table_row && row.table_row.cells) || [];
+      const renderedCells = cells
+        .map((cell) => `      <${cellTag}>${escapeHtml(plainText(cell)).replace(/\n/g, "<br />")}</${cellTag}>`)
+        .join("\n");
+
+      return ["    <tr>", renderedCells, "    </tr>"].join("\n");
+    })
+    .join("\n");
+}
+
+function renderFallbackBlock(type, richText) {
+  const text = plainText(richText).trim();
+
+  if (!text) {
+    return "";
+  }
+
+  return `<!-- Unsupported Notion block: ${type} -->\n${escapeMarkdownText(text)}`;
+}
+
+function renderRichText(richText) {
+  return (richText || []).map(renderRichTextItem).join("");
+}
+
+function renderRichTextItem(item) {
+  if (!item) {
+    return "";
+  }
+
+  const annotations = item.annotations || {};
+  const isEquation = item.type === "equation";
+  const rawText = isEquation ? `$${item.equation.expression || ""}$` : item.plain_text || "";
+  let text;
+
+  if (annotations.code) {
+    text = wrapInlineCode(rawText);
+  } else if (isEquation) {
+    text = rawText;
+  } else {
+    text = escapeMarkdownText(rawText);
+  }
+
+  if (!annotations.code) {
+    if (annotations.bold) {
+      text = `**${text}**`;
+    }
+    if (annotations.italic) {
+      text = `*${text}*`;
+    }
+    if (annotations.strikethrough) {
+      text = `~~${text}~~`;
+    }
+    if (annotations.underline) {
+      text = `<u>${text}</u>`;
+    }
+  }
+
+  if (item.href) {
+    text = `[${text}](${item.href})`;
+  }
+
+  return text;
+}
+
+function markdownToNotionBlocks(markdown) {
+  const lines = String(markdown || "").replace(/\r/g, "").split("\n");
+  const blocks = [];
+  let index = 0;
+
+  while (index < lines.length) {
+    const line = lines[index];
+
+    if (!line.trim()) {
+      index += 1;
+      continue;
+    }
+
+    const codeStart = line.match(/^```([A-Za-z0-9_+-]+)?\s*$/);
+    if (codeStart) {
+      const language = normalizeCodeLanguage(codeStart[1]);
+      const codeLines = [];
+      index += 1;
+
+      while (index < lines.length && !/^```/.test(lines[index])) {
+        codeLines.push(lines[index]);
+        index += 1;
+      }
+
+      if (index < lines.length && /^```/.test(lines[index])) {
+        index += 1;
+      }
+
+      blocks.push({
+        object: "block",
+        type: "code",
+        code: {
+          language,
+          rich_text: richTextFromPlainText(codeLines.join("\n")),
+        },
+      });
+      continue;
+    }
+
+    if (/^---\s*$/.test(line.trim())) {
+      blocks.push({ object: "block", type: "divider", divider: {} });
+      index += 1;
+      continue;
+    }
+
+    if (/^###\s+/.test(line)) {
+      blocks.push(makeTextBlock("heading_3", line.replace(/^###\s+/, "")));
+      index += 1;
+      continue;
+    }
+
+    if (/^##\s+/.test(line)) {
+      blocks.push(makeTextBlock("heading_2", line.replace(/^##\s+/, "")));
+      index += 1;
+      continue;
+    }
+
+    if (/^#\s+/.test(line)) {
+      blocks.push(makeTextBlock("heading_1", line.replace(/^#\s+/, "")));
+      index += 1;
+      continue;
+    }
+
+    if (/^>\s?/.test(line)) {
+      const quoted = [];
+
+      while (index < lines.length && /^>\s?/.test(lines[index])) {
+        quoted.push(lines[index].replace(/^>\s?/, ""));
+        index += 1;
+      }
+
+      blocks.push(makeTextBlock("quote", quoted.join("\n")));
+      continue;
+    }
+
+    if (/^-\s+/.test(line)) {
+      while (index < lines.length && /^-\s+/.test(lines[index])) {
+        blocks.push(makeTextBlock("bulleted_list_item", lines[index].replace(/^-\s+/, "")));
+        index += 1;
+      }
+      continue;
+    }
+
+    if (/^\d+\.\s+/.test(line)) {
+      while (index < lines.length && /^\d+\.\s+/.test(lines[index])) {
+        blocks.push(makeTextBlock("numbered_list_item", lines[index].replace(/^\d+\.\s+/, "")));
+        index += 1;
+      }
+      continue;
+    }
+
+    const paragraph = [];
+
+    while (index < lines.length && shouldStayInParagraph(lines[index])) {
+      paragraph.push(lines[index]);
+      index += 1;
+    }
+
+    blocks.push(makeTextBlock("paragraph", paragraph.join("\n")));
+  }
+
+  return blocks;
+}
+
+function extractTitleAndBody(markdown, fallbackTitle = "Untitled") {
+  const lines = String(markdown || "").replace(/\r/g, "").split("\n");
+
+  if (lines.length && /^#\s+/.test(lines[0])) {
+    const title = lines[0].replace(/^#\s+/, "").trim() || fallbackTitle;
+    const body = lines.slice(1).join("\n").replace(/^\s+/, "");
+
+    return { title, body };
+  }
+
+  return { title: fallbackTitle, body: String(markdown || "") };
+}
+
+function shouldStayInParagraph(line) {
+  if (!line.trim()) {
+    return false;
+  }
+
+  return !/^(#{1,3}\s+|>\s?|-\s+|\d+\.\s+|```|---\s*$)/.test(line);
+}
+
+function makeTextBlock(type, text) {
+  const plain = stripInlineMarkdown(text);
+
+  switch (type) {
+    case "heading_1":
+      return { object: "block", type, heading_1: { rich_text: richTextFromPlainText(plain) } };
+    case "heading_2":
+      return { object: "block", type, heading_2: { rich_text: richTextFromPlainText(plain) } };
+    case "heading_3":
+      return { object: "block", type, heading_3: { rich_text: richTextFromPlainText(plain) } };
+    case "quote":
+      return { object: "block", type, quote: { rich_text: richTextFromPlainText(plain) } };
+    case "bulleted_list_item":
+      return { object: "block", type, bulleted_list_item: { rich_text: richTextFromPlainText(plain) } };
+    case "numbered_list_item":
+      return { object: "block", type, numbered_list_item: { rich_text: richTextFromPlainText(plain) } };
+    default:
+      return { object: "block", type: "paragraph", paragraph: { rich_text: richTextFromPlainText(plain) } };
+  }
+}
+
+function normalizeCodeLanguage(language) {
+  const normalized = String(language || "").trim().toLowerCase();
+  return normalized || "plain text";
+}
+
+function stripInlineMarkdown(value) {
+  return String(value || "")
+    .replace(/\[(.*?)\]\((.*?)\)/g, "$1 ($2)")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*(.*?)\*\*/g, "$1")
+    .replace(/\*(.*?)\*/g, "$1")
+    .replace(/__(.*?)__/g, "$1")
+    .replace(/_(.*?)_/g, "$1")
+    .replace(/~~(.*?)~~/g, "$1")
+    .replace(/<u>(.*?)<\/u>/g, "$1")
+    .trim();
+}
+
+function plainText(richText) {
+  return (richText || []).map((item) => item.plain_text || "").join("");
+}
+
+function getFileUrl(data) {
+  if (!data || !data.type) {
+    return "";
+  }
+
+  if (data.type === "external" && data.external) {
+    return data.external.url || "";
+  }
+
+  if (data.type === "file" && data.file) {
+    return data.file.url || "";
+  }
+
+  return "";
+}
+
+function prefixLines(value, prefix) {
+  return String(value || "")
+    .split("\n")
+    .map((line) => (line ? `${prefix}${line}` : prefix.trimEnd()))
+    .join("\n");
+}
+
+function indentBlock(value, depth) {
+  if (!value) {
+    return "";
+  }
+
+  const indent = " ".repeat(depth * 4);
+
+  return String(value)
+    .split("\n")
+    .map((line) => (line ? `${indent}${line}` : ""))
+    .join("\n");
+}
+
+function withTrailingChildren(rendered, children, depth) {
+  const nested = renderBlocks(children || [], depth + 1).trim();
+
+  if (!rendered) {
+    return nested;
+  }
+
+  return nested ? `${rendered}\n\n${nested}` : rendered;
+}
+
+function wrapInlineCode(value) {
+  const backticks = (String(value).match(/`+/g) || []).map((token) => token.length);
+  const fence = "`".repeat(Math.max(1, ...backticks) + 1);
+
+  return `${fence}${value}${fence}`;
+}
+
+function makeFence(value) {
+  const fences = (String(value).match(/`{3,}/g) || []).map((token) => token.length);
+  return "`".repeat(Math.max(3, ...fences) + 1);
+}
+
+function escapeMarkdownText(value) {
+  return String(value || "").replace(/([\\`*_[\]<>])/g, "\\$1");
+}
+
+function escapeHtml(value) {
+  return String(value || "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function richTextFromPlainText(value) {
+  const text = String(value || "");
+
+  if (!text) {
+    return [];
+  }
+
+  const chunks = [];
+
+  for (let index = 0; index < text.length; index += 2000) {
+    chunks.push({
+      type: "text",
+      text: { content: text.slice(index, index + 2000) },
+    });
+  }
+
+  return chunks;
+}
+
+module.exports = {
+  extractTitleAndBody,
+  markdownToNotionBlocks,
+  renderDocument,
+};

--- a/scripts/lib/notion-workflows.js
+++ b/scripts/lib/notion-workflows.js
@@ -1,0 +1,525 @@
+const fs = require("fs/promises");
+const path = require("path");
+
+const {
+  buildPropertyFilter,
+  fetchBlockTree,
+  fetchPage,
+  fetchSourceSchema,
+  getNotionConfig,
+  normalizeName,
+  querySourcePages,
+  validateSourceConfig,
+  validateToken,
+} = require("./notion-api");
+const { renderDocument } = require("./notion-render");
+
+const READY_STATUS_PROPERTY = process.env.NOTION_STATUS_PROPERTY || "status";
+const TYPE_PROPERTY = process.env.NOTION_TYPE_PROPERTY || "type";
+const PLATFORM_PROPERTY = process.env.NOTION_PLATFORM_PROPERTY || "platform";
+
+const WORKFLOWS = {
+  blog: {
+    outputStem: "create-blog",
+    typeValue: process.env.NOTION_BLOG_TYPE_VALUE || "blog",
+    platformValue: process.env.NOTION_BLOG_PLATFORM_VALUE || "",
+    sourcePageId: process.env.NOTION_BLOG_SOURCE_PAGE_ID || "",
+    sourcePath: process.env.NOTION_BLOG_SOURCE_PATH || "",
+  },
+  linkedin: {
+    outputStem: "create-linkedin",
+    typeValue: process.env.NOTION_LINKEDIN_TYPE_VALUE || "linkedin",
+    platformValue: process.env.NOTION_LINKEDIN_PLATFORM_VALUE || "",
+    sourcePageId: process.env.NOTION_LINKEDIN_SOURCE_PAGE_ID || "",
+    sourcePath: process.env.NOTION_LINKEDIN_SOURCE_PATH || "",
+  },
+};
+
+async function pullWorkflowSource(workflowName, options = {}) {
+  const env = options.env || process.env;
+  const workflow = getWorkflowDefinition(workflowName, env, options);
+  const notionConfig = getNotionConfig(env);
+  validateToken(notionConfig);
+
+  const source = await resolveWorkflowSource(notionConfig, workflow, env);
+  const blocks = await fetchBlockTree(notionConfig, source.page.id);
+  const title = getPageTitle(source.page);
+  const markdown = renderDocument(title, blocks);
+
+  return {
+    markdown,
+    metadata: {
+      workflow: workflowName,
+      outputStem: workflow.outputStem,
+      sourceId: source.page.id,
+      sourceUrl: source.page.url || "",
+      sourceTitle: title,
+      sourceKind: source.kind,
+      pulledAt: new Date().toISOString(),
+      sourcePath: source.path || "",
+      rootPageId: source.rootPageId || "",
+      filters: source.filters || null,
+    },
+  };
+}
+
+async function writeWorkflowArtifacts(result, outputDir = path.resolve(__dirname, "..", "..", "output")) {
+  const markdownPath = path.join(outputDir, `${result.metadata.outputStem}-source.md`);
+  const metadataPath = path.join(outputDir, `${result.metadata.outputStem}-source.json`);
+
+  await fs.mkdir(outputDir, { recursive: true });
+  await fs.writeFile(markdownPath, ensureTrailingNewline(result.markdown), "utf8");
+  await fs.writeFile(metadataPath, `${JSON.stringify(result.metadata, null, 2)}\n`, "utf8");
+
+  return { markdownPath, metadataPath };
+}
+
+async function listPageTree(options = {}) {
+  const env = options.env || process.env;
+  const notionConfig = getNotionConfig(env);
+  validateToken(notionConfig);
+
+  const rootPageId = options.rootPageId || env.NOTION_ROOT_PAGE_ID;
+  const sourcePath = options.sourcePath || "";
+  const maxDepth = Number.isFinite(options.maxDepth) ? options.maxDepth : getListTreeDepthLimit(env);
+
+  if (!rootPageId) {
+    throw new Error("Missing NOTION_ROOT_PAGE_ID.");
+  }
+
+  const startNode = sourcePath
+    ? await resolvePageByPath(notionConfig, rootPageId, sourcePath)
+    : { page: await fetchPage(notionConfig, rootPageId), path: "" };
+  const tree = await buildReferencedPageTree(notionConfig, startNode.page.id, {
+    maxDepth,
+  });
+  const rootPage = tree.page;
+
+  if (!tree) {
+    throw new Error(`Could not build a page tree from root page ${rootPageId}.`);
+  }
+
+  return {
+    rootPage,
+    tree,
+    paths: flattenPageTree(tree),
+  };
+}
+
+function getWorkflowDefinition(workflowName, env = process.env, options = {}) {
+  switch (workflowName) {
+    case "blog":
+      return {
+        outputStem: "create-blog",
+        typeValue: env.NOTION_BLOG_TYPE_VALUE || WORKFLOWS.blog.typeValue,
+        platformValue: env.NOTION_BLOG_PLATFORM_VALUE || "",
+        sourcePageId: options.sourcePageId || env.NOTION_BLOG_SOURCE_PAGE_ID || "",
+        sourcePath: options.sourcePath || env.NOTION_BLOG_SOURCE_PATH || "",
+      };
+    case "linkedin":
+      return {
+        outputStem: "create-linkedin",
+        typeValue: env.NOTION_LINKEDIN_TYPE_VALUE || WORKFLOWS.linkedin.typeValue,
+        platformValue: env.NOTION_LINKEDIN_PLATFORM_VALUE || "",
+        sourcePageId: options.sourcePageId || env.NOTION_LINKEDIN_SOURCE_PAGE_ID || "",
+        sourcePath: options.sourcePath || env.NOTION_LINKEDIN_SOURCE_PATH || "",
+      };
+    default:
+      throw new Error(`Unknown workflow "${workflowName}". Expected one of: ${Object.keys(WORKFLOWS).join(", ")}`);
+  }
+}
+
+async function resolveWorkflowSource(notionConfig, workflow, env) {
+  if (workflow.sourcePageId) {
+    return {
+      kind: "page_id",
+      page: await fetchPage(notionConfig, workflow.sourcePageId),
+      path: "",
+      rootPageId: "",
+      filters: null,
+    };
+  }
+
+  if (workflow.sourcePath) {
+    const rootPageId = env.NOTION_ROOT_PAGE_ID;
+
+    if (!rootPageId) {
+      throw new Error("Path mode requires NOTION_ROOT_PAGE_ID.");
+    }
+
+    const resolved = await resolvePageByPath(notionConfig, rootPageId, workflow.sourcePath);
+    return {
+      kind: "page_path",
+      page: resolved.page,
+      path: resolved.path,
+      rootPageId,
+      filters: null,
+    };
+  }
+
+  validateSourceConfig(notionConfig);
+
+  const source = await fetchSourceSchema(notionConfig);
+  const filters = [
+    buildPropertyFilter(source.properties, READY_STATUS_PROPERTY, env.NOTION_READY_STATUS_VALUE || "Ready"),
+    buildPropertyFilter(source.properties, TYPE_PROPERTY, workflow.typeValue),
+    buildPropertyFilter(source.properties, PLATFORM_PROPERTY, workflow.platformValue),
+  ].filter(Boolean);
+
+  const page = await fetchReadyPage(notionConfig, filters);
+  return {
+    kind: notionConfig.sourceKind,
+    page,
+    path: "",
+    rootPageId: "",
+    filters: {
+      status: env.NOTION_READY_STATUS_VALUE || "Ready",
+      type: workflow.typeValue,
+      platform: workflow.platformValue || "",
+    },
+  };
+}
+
+async function resolvePageByPath(notionConfig, rootPageId, requestedPath) {
+  const pathSegments = normalizePathSegments(requestedPath);
+
+  if (!pathSegments.length) {
+    throw new Error("Source path is empty.");
+  }
+
+  const rootPage = await fetchPage(notionConfig, rootPageId);
+  const rootTitle = getPageTitle(rootPage);
+  const firstSegmentMatchesRoot = normalizeName(pathSegments[0]) === normalizeName(rootTitle);
+  const relativeSegments = firstSegmentMatchesRoot ? pathSegments.slice(1) : pathSegments;
+  let currentPage = rootPage;
+  const resolvedSegments = [rootTitle];
+
+  for (const segment of relativeSegments) {
+    const children = await listReferencedPages(notionConfig, currentPage.id);
+    const normalizedSegment = normalizeName(segment);
+    const matches = children.filter((child) => normalizeName(child.title) === normalizedSegment);
+
+    if (!matches.length) {
+      const available = children.map((child) => child.title).join(", ");
+      throw new Error(
+        `Could not resolve path segment "${segment}" under "${getPageTitle(currentPage)}". Available: ${available || "(none)"}`,
+      );
+    }
+
+    if (matches.length > 1) {
+      throw new Error(`Path segment "${segment}" is ambiguous under "${getPageTitle(currentPage)}".`);
+    }
+
+    currentPage = matches[0].page;
+    resolvedSegments.push(matches[0].title);
+  }
+
+  return {
+    page: currentPage,
+    path: resolvedSegments.join("/"),
+  };
+}
+
+async function fetchReadyPage(notionConfig, filters) {
+  const response = await querySourcePages(notionConfig, {
+    filter: { and: filters },
+    page_size: 100,
+  });
+
+  const candidates = (response.results || [])
+    .filter((page) => page.object === "page")
+    .filter((page) => !page.archived && !page.is_archived && !page.in_trash)
+    .sort((left, right) => {
+      const leftTime = new Date(left.created_time || left.last_edited_time || 0).getTime();
+      const rightTime = new Date(right.created_time || right.last_edited_time || 0).getTime();
+      return leftTime - rightTime;
+    });
+
+  if (!candidates.length) {
+    const filterSummary = filters.map((filter) => JSON.stringify(filter)).join(", ");
+    throw new Error(`No Notion page matched the configured filters. Filters: ${filterSummary}`);
+  }
+
+  return candidates[0];
+}
+
+async function buildReferencedPageTree(notionConfig, rootPageId, options = {}) {
+  const maxDepth = Number.isFinite(options.maxDepth) ? options.maxDepth : 4;
+  const pageCache = new Map();
+  const blockCache = new Map();
+
+  async function loadPage(pageId) {
+    if (!pageCache.has(pageId)) {
+      pageCache.set(pageId, fetchPage(notionConfig, pageId));
+    }
+
+    return pageCache.get(pageId);
+  }
+
+  async function loadBlocks(pageId) {
+    if (!blockCache.has(pageId)) {
+      blockCache.set(pageId, fetchBlockTree(notionConfig, pageId));
+    }
+
+    return blockCache.get(pageId);
+  }
+
+  async function buildNode(pageId, parent = null, ancestorIds = new Set(), depth = 0) {
+    const page = await loadPage(pageId);
+    const node = {
+      page,
+      title: getPageTitle(page),
+      parent,
+      children: [],
+    };
+
+    if (depth >= maxDepth) {
+      return node;
+    }
+
+    const children = await listReferencedPages(notionConfig, pageId, {
+      pageCache,
+      blockCache,
+    });
+
+    for (const child of children) {
+      if (ancestorIds.has(child.page.id) || child.page.id === pageId) {
+        continue;
+      }
+
+      try {
+        const nextAncestors = new Set(ancestorIds);
+        nextAncestors.add(pageId);
+        const childNode = await buildNode(child.page.id, node, nextAncestors, depth + 1);
+        node.children.push(childNode);
+      } catch (error) {
+        continue;
+      }
+    }
+
+    node.children.sort((left, right) => left.title.localeCompare(right.title, "ko"));
+    return node;
+  }
+
+  return buildNode(rootPageId, null, new Set(), 0);
+}
+
+async function listReferencedPages(notionConfig, pageId, caches = {}) {
+  const pageCache = caches.pageCache || new Map();
+  const blockCache = caches.blockCache || new Map();
+
+  async function loadPage(localPageId) {
+    if (!pageCache.has(localPageId)) {
+      pageCache.set(localPageId, fetchPage(notionConfig, localPageId));
+    }
+
+    return pageCache.get(localPageId);
+  }
+
+  async function loadBlocks(localPageId) {
+    if (!blockCache.has(localPageId)) {
+      blockCache.set(localPageId, fetchBlockTree(notionConfig, localPageId));
+    }
+
+    return blockCache.get(localPageId);
+  }
+
+  const blocks = await loadBlocks(pageId);
+  const references = collectLinkedPageReferences(blocks);
+  const uniquePageIds = Array.from(new Set(references.map((item) => item.pageId).filter(Boolean)));
+  const children = [];
+
+  for (const childPageId of uniquePageIds) {
+    try {
+      const page = await loadPage(childPageId);
+      children.push({
+        page,
+        title: getPageTitle(page),
+      });
+    } catch (error) {
+      continue;
+    }
+  }
+
+  children.sort((left, right) => left.title.localeCompare(right.title, "ko"));
+  return children;
+}
+
+function flattenPageTree(rootNode) {
+  const lines = [];
+
+  visitTree(rootNode, (node) => {
+    lines.push({
+      id: node.page.id,
+      title: node.title,
+      path: flattenNodePath(node),
+      url: node.page.url || "",
+      depth: getNodeDepth(node),
+    });
+  });
+
+  return lines;
+}
+
+function visitTree(node, visitor) {
+  visitor(node);
+  for (const child of node.children) {
+    visitTree(child, visitor);
+  }
+}
+
+function flattenNodePath(node) {
+  const segments = [];
+  let current = node;
+
+  while (current) {
+    segments.push(current.title);
+    current = current.parent;
+  }
+
+  return segments.reverse().join("/");
+}
+
+function getNodeDepth(node) {
+  let depth = 0;
+  let current = node.parent;
+
+  while (current) {
+    depth += 1;
+    current = current.parent;
+  }
+
+  return depth;
+}
+
+function normalizePathSegments(sourcePath) {
+  return String(sourcePath || "")
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+}
+
+function collectLinkedPageReferences(blocks) {
+  const references = [];
+
+  for (const block of blocks || []) {
+    collectReferencesFromValue(block, references);
+
+    if (block.type === "child_page" && block.id) {
+      references.push({ pageId: block.id, source: "child_page" });
+    }
+
+    if (block.type === "link_to_page") {
+      const pageId = extractPageIdFromLinkToPage(block.link_to_page);
+
+      if (pageId) {
+        references.push({ pageId, source: "link_to_page" });
+      }
+    }
+  }
+
+  return references;
+}
+
+function collectReferencesFromValue(value, references) {
+  if (!value) {
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectReferencesFromValue(item, references);
+    }
+    return;
+  }
+
+  if (typeof value !== "object") {
+    return;
+  }
+
+  if (value.type === "mention" && value.mention && value.mention.type === "page" && value.mention.page) {
+    references.push({ pageId: value.mention.page.id, source: "page_mention" });
+  }
+
+  const hrefPageId = extractPageIdFromUrl(value.href);
+  if (hrefPageId) {
+    references.push({ pageId: hrefPageId, source: "href" });
+  }
+
+  const urlPageId = extractPageIdFromUrl(value.url);
+  if (urlPageId) {
+    references.push({ pageId: urlPageId, source: "url" });
+  }
+
+  for (const childValue of Object.values(value)) {
+    collectReferencesFromValue(childValue, references);
+  }
+}
+
+function extractPageIdFromLinkToPage(linkToPage) {
+  if (!linkToPage || typeof linkToPage !== "object") {
+    return "";
+  }
+
+  if (linkToPage.type === "page_id" && linkToPage.page_id) {
+    return linkToPage.page_id;
+  }
+
+  if (linkToPage.page_id) {
+    return linkToPage.page_id;
+  }
+
+  return "";
+}
+
+function extractPageIdFromUrl(url) {
+  const value = String(url || "");
+
+  if (!/notion\.so/i.test(value)) {
+    return "";
+  }
+
+  const hyphenated = value.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i);
+  if (hyphenated) {
+    return hyphenated[1];
+  }
+
+  const compact = value.match(/([0-9a-f]{32})(?:\?|#|$)/i);
+  if (compact) {
+    const raw = compact[1];
+    return `${raw.slice(0, 8)}-${raw.slice(8, 12)}-${raw.slice(12, 16)}-${raw.slice(16, 20)}-${raw.slice(20)}`;
+  }
+
+  return "";
+}
+
+function getTreeDepthLimit(env = process.env) {
+  const parsed = Number.parseInt(env.NOTION_TREE_MAX_DEPTH || "4", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 4;
+}
+
+function getListTreeDepthLimit(env = process.env) {
+  const parsed = Number.parseInt(env.NOTION_TREE_LIST_DEPTH || "1", 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 1;
+}
+
+function getPageTitle(page) {
+  const titleProperty = Object.values(page.properties || {}).find((property) => property.type === "title");
+  const title = titleProperty ? plainText(titleProperty.title) : "";
+
+  return title || "Untitled";
+}
+
+function plainText(richText) {
+  return (richText || []).map((item) => item.plain_text || "").join("");
+}
+
+function ensureTrailingNewline(value) {
+  return value.endsWith("\n") ? value : `${value}\n`;
+}
+
+module.exports = {
+  listPageTree,
+  pullWorkflowSource,
+  writeWorkflowArtifacts,
+};

--- a/scripts/lib/openai-api.js
+++ b/scripts/lib/openai-api.js
@@ -1,0 +1,157 @@
+const https = require("https");
+
+function getOpenAIConfig(env = process.env) {
+  return {
+    apiKey: env.OPENAI_API_KEY || "",
+    model: env.OPENAI_MODEL || "gpt-5",
+    maxOutputTokens: toPositiveInteger(env.OPENAI_MAX_OUTPUT_TOKENS, 5000),
+  };
+}
+
+function validateOpenAIConfig(config) {
+  if (!config.apiKey) {
+    throw new Error("Missing OPENAI_API_KEY for blog draft generation.");
+  }
+}
+
+async function generateMarkdownDraft({ instructions, sourceMarkdown, sourceMeta, env = process.env }) {
+  const config = getOpenAIConfig(env);
+  validateOpenAIConfig(config);
+
+  const metadataBlock = JSON.stringify(sourceMeta || {}, null, 2);
+  const input = [
+    {
+      role: "user",
+      content: [
+        {
+          type: "input_text",
+          text: [
+            "Rewrite the following Notion source note into a Tistory-ready Markdown blog post.",
+            "Return only the final Markdown article.",
+            "",
+            "[Source Metadata]",
+            metadataBlock,
+            "",
+            "[Source Markdown]",
+            sourceMarkdown,
+          ].join("\n"),
+        },
+      ],
+    },
+  ];
+
+  const response = await openAIRequest(config, {
+    method: "POST",
+    resourcePath: "/v1/responses",
+    body: {
+      model: config.model,
+      instructions,
+      input,
+      max_output_tokens: config.maxOutputTokens,
+    },
+  });
+
+  const outputText = extractOutputText(response).trim();
+
+  if (!outputText) {
+    throw new Error("OpenAI returned an empty draft.");
+  }
+
+  return {
+    markdown: ensureTrailingNewline(outputText),
+    response,
+  };
+}
+
+function extractOutputText(response) {
+  if (response && typeof response.output_text === "string" && response.output_text.trim()) {
+    return response.output_text;
+  }
+
+  const outputs = Array.isArray(response && response.output) ? response.output : [];
+  const chunks = [];
+
+  for (const item of outputs) {
+    const contents = Array.isArray(item && item.content) ? item.content : [];
+    for (const content of contents) {
+      if (typeof content.text === "string") {
+        chunks.push(content.text);
+      } else if (content && typeof content === "object" && typeof content.output_text === "string") {
+        chunks.push(content.output_text);
+      }
+    }
+  }
+
+  return chunks.join("\n").trim();
+}
+
+function openAIRequest(config, { method, resourcePath, body }) {
+  const requestBody = body ? JSON.stringify(body) : null;
+  const url = new URL(`https://api.openai.com${resourcePath}`);
+
+  return new Promise((resolve, reject) => {
+    const request = https.request(
+      url,
+      {
+        method,
+        headers: {
+          Authorization: `Bearer ${config.apiKey}`,
+          "Content-Type": "application/json",
+          ...(requestBody ? { "Content-Length": Buffer.byteLength(requestBody) } : {}),
+        },
+      },
+      (response) => {
+        const chunks = [];
+
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => {
+          const rawBody = Buffer.concat(chunks).toString("utf8");
+          const json = rawBody ? tryParseJson(rawBody) : {};
+
+          if (response.statusCode >= 200 && response.statusCode < 300) {
+            resolve(json);
+            return;
+          }
+
+          const message =
+            (json && json.error && json.error.message) ||
+            (json && json.message) ||
+            `OpenAI API request failed with status ${response.statusCode}.`;
+
+          reject(new Error(message));
+        });
+      },
+    );
+
+    request.on("error", reject);
+
+    if (requestBody) {
+      request.write(requestBody);
+    }
+
+    request.end();
+  });
+}
+
+function tryParseJson(value) {
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    return { message: value };
+  }
+}
+
+function toPositiveInteger(value, fallback) {
+  const parsed = Number.parseInt(String(value || ""), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function ensureTrailingNewline(value) {
+  return value.endsWith("\n") ? value : `${value}\n`;
+}
+
+module.exports = {
+  generateMarkdownDraft,
+  getOpenAIConfig,
+  validateOpenAIConfig,
+};

--- a/scripts/lib/parse-source-input.js
+++ b/scripts/lib/parse-source-input.js
@@ -1,0 +1,72 @@
+function parseSourceInput(rawValue) {
+  const value = String(rawValue || "").trim();
+
+  if (!value) {
+    return {
+      sourcePageId: "",
+      sourcePath: "",
+      sourceInputKind: "default",
+      sourceInputValue: "",
+    };
+  }
+
+  const pageId = extractPageId(value);
+
+  if (pageId) {
+    return {
+      sourcePageId: pageId,
+      sourcePath: "",
+      sourceInputKind: /notion\.so/i.test(value) ? "url" : "page_id",
+      sourceInputValue: value,
+    };
+  }
+
+  return {
+    sourcePageId: "",
+    sourcePath: value,
+    sourceInputKind: "path",
+    sourceInputValue: value,
+  };
+}
+
+function extractPageId(value) {
+  const trimmed = String(value || "").trim();
+
+  if (!trimmed) {
+    return "";
+  }
+
+  const hyphenated = trimmed.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+  if (hyphenated) {
+    return hyphenated[0].toLowerCase();
+  }
+
+  const compact = trimmed.match(/^[0-9a-f]{32}$/i);
+  if (compact) {
+    return formatCompactPageId(compact[0]);
+  }
+
+  if (/notion\.so/i.test(trimmed)) {
+    const hyphenatedUrl = trimmed.match(/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i);
+    if (hyphenatedUrl) {
+      return hyphenatedUrl[1].toLowerCase();
+    }
+
+    const compactUrl = trimmed.match(/([0-9a-f]{32})(?:\?|#|$)/i);
+    if (compactUrl) {
+      return formatCompactPageId(compactUrl[1]);
+    }
+  }
+
+  return "";
+}
+
+function formatCompactPageId(value) {
+  const raw = String(value || "").toLowerCase();
+  return `${raw.slice(0, 8)}-${raw.slice(8, 12)}-${raw.slice(12, 16)}-${raw.slice(16, 20)}-${raw.slice(20)}`;
+}
+
+module.exports = {
+  extractPageId,
+  parseSourceInput,
+};

--- a/scripts/lib/publish-blog-draft.js
+++ b/scripts/lib/publish-blog-draft.js
@@ -1,0 +1,111 @@
+const fs = require("fs/promises");
+const path = require("path");
+
+const {
+  appendBlockChildren,
+  createPage,
+  getNotionConfig,
+  validateToken,
+} = require("./notion-api");
+const { extractTitleAndBody, markdownToNotionBlocks } = require("./notion-render");
+const { extractPageId } = require("./parse-source-input");
+
+async function publishBlogDraft(options = {}) {
+  const env = options.env || process.env;
+  const notionConfig = getNotionConfig(env);
+  validateToken(notionConfig);
+
+  const workspaceRoot = options.workspaceRoot || path.resolve(__dirname, "..", "..");
+  const targetInput = options.targetInput || env.NOTION_BLOG_TARGET_PAGE_ID || "";
+  const inputPath = path.resolve(options.inputPath || path.join(workspaceRoot, "output", "create-blog.md"));
+  const sourceMetaPath = path.resolve(
+    options.sourceMetaPath || path.join(workspaceRoot, "output", "create-blog-source.json"),
+  );
+  const resultPath = path.resolve(
+    options.resultPath || path.join(workspaceRoot, "output", "create-blog-published.json"),
+  );
+  const targetPageId = extractPageId(targetInput);
+
+  if (!targetPageId) {
+    throw new Error("Missing target page id or Notion page URL for the blog draft.");
+  }
+
+  const markdown = await fs.readFile(inputPath, "utf8");
+  const sourceMeta = await readOptionalJson(sourceMetaPath);
+  const { title, body } = extractTitleAndBody(markdown, "Blog Draft");
+  const bodyWithSource = prependSourceReference(body, sourceMeta);
+  const blocks = markdownToNotionBlocks(bodyWithSource);
+
+  if (!blocks.length) {
+    throw new Error(`No publishable blog content found in ${inputPath}`);
+  }
+
+  const firstChunk = blocks.slice(0, 100);
+  const remainder = chunk(blocks.slice(100), 100);
+  const createdPage = await createPage(notionConfig, {
+    parent: { page_id: targetPageId },
+    properties: {
+      title: {
+        title: [{ type: "text", text: { content: title } }],
+      },
+    },
+    children: firstChunk,
+  });
+
+  for (const blockGroup of remainder) {
+    await appendBlockChildren(notionConfig, createdPage.id, blockGroup);
+  }
+
+  const result = {
+    createdAt: new Date().toISOString(),
+    inputPath,
+    sourceMetaPath,
+    parentPageId: targetPageId,
+    pageId: createdPage.id,
+    url: createdPage.url || "",
+    title,
+  };
+
+  await fs.mkdir(path.dirname(resultPath), { recursive: true });
+  await fs.writeFile(resultPath, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+  return result;
+}
+
+function prependSourceReference(body, sourceMeta) {
+  if (!sourceMeta || !sourceMeta.sourceTitle) {
+    return body;
+  }
+
+  const sourceLine = sourceMeta.sourceUrl
+    ? `Source: ${sourceMeta.sourceTitle} (${sourceMeta.sourceUrl})`
+    : `Source: ${sourceMeta.sourceTitle}`;
+
+  return [sourceLine, "", body].filter(Boolean).join("\n");
+}
+
+function chunk(items, size) {
+  const groups = [];
+
+  for (let index = 0; index < items.length; index += size) {
+    groups.push(items.slice(index, index + size));
+  }
+
+  return groups;
+}
+
+async function readOptionalJson(filePath) {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    return JSON.parse(raw);
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+module.exports = {
+  publishBlogDraft,
+};

--- a/scripts/list-notion-tree.js
+++ b/scripts/list-notion-tree.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+const fs = require("fs/promises");
+const path = require("path");
+
+const { loadLocalEnv } = require("./lib/load-env");
+
+loadLocalEnv();
+
+const { listPageTree } = require("./lib/notion-workflows");
+
+const OUTPUT_DIR = path.resolve(__dirname, "..", "output");
+const TEXT_OUTPUT_PATH = path.join(OUTPUT_DIR, "notion-tree.txt");
+const JSON_OUTPUT_PATH = path.join(OUTPUT_DIR, "notion-tree.json");
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});
+
+async function main() {
+  const args = process.argv.slice(2);
+  const parsed = parseArgs(args);
+  const result = await listPageTree(parsed);
+  const text = result.paths
+    .map((item) => `${"  ".repeat(item.depth)}- ${item.path} [${item.id}]`)
+    .join("\n");
+
+  await fs.mkdir(OUTPUT_DIR, { recursive: true });
+  await fs.writeFile(TEXT_OUTPUT_PATH, `${text}\n`, "utf8");
+  await fs.writeFile(JSON_OUTPUT_PATH, `${JSON.stringify(result.paths, null, 2)}\n`, "utf8");
+
+  console.log(text);
+  console.log(`\nSaved tree to ${TEXT_OUTPUT_PATH}`);
+}
+
+function parseArgs(args) {
+  const result = {
+    rootPageId: process.env.NOTION_ROOT_PAGE_ID || "",
+    sourcePath: "",
+    maxDepth: undefined,
+  };
+
+  for (const arg of args) {
+    if (!arg) {
+      continue;
+    }
+
+    if (isUuidLike(arg)) {
+      result.rootPageId = arg;
+      continue;
+    }
+
+    if (/^\d+$/.test(arg)) {
+      result.maxDepth = Number.parseInt(arg, 10);
+      continue;
+    }
+
+    result.sourcePath = arg;
+  }
+
+  return result;
+}
+
+function isUuidLike(value) {
+  return /^[0-9a-f]{32}$/i.test(value) || /^[0-9a-f-]{36}$/i.test(value);
+}

--- a/scripts/publish-blog-draft.js
+++ b/scripts/publish-blog-draft.js
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+const { loadLocalEnv } = require("./lib/load-env");
+
+loadLocalEnv();
+
+const { publishBlogDraft } = require("./lib/publish-blog-draft");
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});
+
+async function main() {
+  const result = await publishBlogDraft({
+    targetInput: process.argv[2] || process.env.NOTION_BLOG_TARGET_PAGE_ID || "",
+    inputPath: process.argv[3],
+    sourceMetaPath: process.argv[4],
+  });
+
+  console.log(`Created blog draft page "${result.title}" at ${result.url || result.pageId}`);
+}

--- a/scripts/publish-linkedin.js
+++ b/scripts/publish-linkedin.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+const fs = require("fs/promises");
+const path = require("path");
+const { loadLocalEnv } = require("./lib/load-env");
+
+loadLocalEnv();
+
+const {
+  appendBlockChildren,
+  buildPropertyValue,
+  createPage,
+  fetchDatabaseSchema,
+  findProperty,
+  findTitlePropertyName,
+  getNotionConfig,
+  validateToken,
+} = require("./lib/notion-api");
+const { extractTitleAndBody, markdownToNotionBlocks } = require("./lib/notion-render");
+
+const WORKSPACE_ROOT = path.resolve(__dirname, "..");
+const DEFAULT_INPUT_PATH = path.join(WORKSPACE_ROOT, "output", "create-linkedin.md");
+const DEFAULT_SOURCE_META_PATH = path.join(WORKSPACE_ROOT, "output", "create-linkedin-source.json");
+const DEFAULT_RESULT_PATH = path.join(WORKSPACE_ROOT, "output", "create-linkedin-published.json");
+const TITLE_SUFFIX = process.env.NOTION_LINKEDIN_TITLE_SUFFIX || " - LinkedIn";
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});
+
+async function main() {
+  const notionConfig = getNotionConfig(process.env);
+  validateToken(notionConfig);
+
+  const inputPath = path.resolve(process.argv[2] || DEFAULT_INPUT_PATH);
+  const sourceMetaPath = path.resolve(process.argv[3] || DEFAULT_SOURCE_META_PATH);
+  const markdown = await fs.readFile(inputPath, "utf8");
+  const sourceMeta = await readOptionalJson(sourceMetaPath);
+
+  const defaultTitle = sourceMeta && sourceMeta.sourceTitle ? `${sourceMeta.sourceTitle}${TITLE_SUFFIX}` : "LinkedIn Draft";
+  const { title, body } = extractTitleAndBody(markdown, defaultTitle);
+  const bodyWithSource = prependSourceReference(body, sourceMeta);
+  const blocks = markdownToNotionBlocks(bodyWithSource);
+
+  if (!blocks.length) {
+    throw new Error(`No publishable content found in ${inputPath}`);
+  }
+
+  const target = await buildTargetConfig(notionConfig, title);
+  const firstChunk = blocks.slice(0, 100);
+  const remainder = chunk(blocks.slice(100), 100);
+  const createdPage = await createPage(notionConfig, {
+    parent: target.parent,
+    properties: target.properties,
+    children: firstChunk,
+  });
+
+  for (const blockGroup of remainder) {
+    await appendBlockChildren(notionConfig, createdPage.id, blockGroup);
+  }
+
+  const result = {
+    createdAt: new Date().toISOString(),
+    inputPath,
+    sourceMetaPath,
+    pageId: createdPage.id,
+    url: createdPage.url || "",
+    title,
+  };
+
+  await fs.mkdir(path.dirname(DEFAULT_RESULT_PATH), { recursive: true });
+  await fs.writeFile(DEFAULT_RESULT_PATH, `${JSON.stringify(result, null, 2)}\n`, "utf8");
+  console.log(`Created LinkedIn page "${title}" at ${createdPage.url || createdPage.id}`);
+}
+
+async function buildTargetConfig(notionConfig, title) {
+  const targetPageId = process.env.NOTION_LINKEDIN_TARGET_PAGE_ID;
+  const targetDatabaseId = process.env.NOTION_LINKEDIN_TARGET_DATABASE_ID;
+
+  if (targetDatabaseId) {
+    const schema = await fetchDatabaseSchema(notionConfig, targetDatabaseId);
+    const titlePropertyName = findTitlePropertyName(schema.properties);
+
+    if (!titlePropertyName) {
+      throw new Error("Could not find a title property in the target Notion database.");
+    }
+
+    const properties = {
+      [titlePropertyName]: buildPropertyValue(schema.properties, titlePropertyName, title),
+    };
+
+    const statusProperty = process.env.NOTION_LINKEDIN_TARGET_STATUS_PROPERTY;
+    const statusValue = process.env.NOTION_LINKEDIN_TARGET_STATUS_VALUE;
+
+    if (statusProperty && statusValue) {
+      const matchedProperty = findProperty(schema.properties, statusProperty);
+
+      if (!matchedProperty) {
+        throw new Error(`Could not find target property "${statusProperty}" in the LinkedIn target database.`);
+      }
+
+      properties[matchedProperty.name] = buildPropertyValue(
+        schema.properties,
+        matchedProperty.name,
+        statusValue,
+      );
+    }
+
+    return {
+      parent: { database_id: targetDatabaseId },
+      properties,
+    };
+  }
+
+  if (targetPageId) {
+    return {
+      parent: { page_id: targetPageId },
+      properties: {
+        title: {
+          title: [{ type: "text", text: { content: title } }],
+        },
+      },
+    };
+  }
+
+  throw new Error(
+    "Missing NOTION_LINKEDIN_TARGET_PAGE_ID or NOTION_LINKEDIN_TARGET_DATABASE_ID.",
+  );
+}
+
+function prependSourceReference(body, sourceMeta) {
+  if (!sourceMeta || !sourceMeta.sourceTitle) {
+    return body;
+  }
+
+  const sourceLine = sourceMeta.sourceUrl
+    ? `Source: ${sourceMeta.sourceTitle} (${sourceMeta.sourceUrl})`
+    : `Source: ${sourceMeta.sourceTitle}`;
+
+  return [sourceLine, "", body].filter(Boolean).join("\n");
+}
+
+function chunk(items, size) {
+  const groups = [];
+
+  for (let index = 0; index < items.length; index += size) {
+    groups.push(items.slice(index, index + size));
+  }
+
+  return groups;
+}
+
+async function readOptionalJson(filePath) {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    return JSON.parse(raw);
+  } catch (error) {
+    if (error && error.code === "ENOENT") {
+      return null;
+    }
+
+    throw error;
+  }
+}

--- a/templates/tistory-blog-draft.md
+++ b/templates/tistory-blog-draft.md
@@ -1,0 +1,153 @@
+# Tistory Blog Draft Template
+
+Use this template when transforming a Notion source note into a Tistory-ready Markdown blog post.
+
+## Role
+
+You are a writing assistant that rewrites a Notion draft into a natural Korean blog post suitable for Tistory.
+
+## Goal
+
+- Rewrite the source note into a natural blog article that can be pasted into Tistory.
+- Keep explanations easy enough for beginners to follow.
+- Use a soft, explanatory tone.
+- Naturally use transitions such as "개발을 하다 보면", "쉽게 말하면", and "정리하면" when they fit.
+
+## Writing Rules
+
+- Write the title in Korean and make it curiosity-driven.
+- Open with an easy introduction to the topic and explain why it matters.
+- Organize the body with `##` and `###`.
+- Keep the original meaning, but rewrite the phrasing to be smoother and easier to read.
+- Add examples only when they genuinely help understanding.
+- Avoid overly short, choppy sentences; write like a real blog post.
+- Avoid academic or overly stiff phrasing.
+- End with a concise summary and closing paragraph.
+- If the source includes code examples, present them in fenced code blocks.
+- Fix typos, spacing, and awkward phrasing automatically.
+
+## Preferred Technical Blog Flow
+
+When the source is a technical topic, follow this flow unless the source clearly needs something else.
+
+1. Problem hook
+   - Start from a pain point developers realistically hit.
+   - Briefly explain why the topic matters in practice.
+2. Existing approach first
+   - Explain the default or common way first.
+   - Show why it becomes inconvenient, messy, or hard to maintain.
+3. Introduce the main concept or library
+   - Present it as the answer to the pain point.
+   - Slightly conversational headings are allowed when natural.
+4. Working principle
+   - Explain how it works in plain language.
+   - Separate important terms or core functions into small subsections.
+5. Usage
+   - Installation
+   - Basic pattern
+   - Practical example such as React integration when relevant
+6. Caution points
+   - Mention realistic mistakes or limits.
+7. Closing
+   - End with a short recommendation and recap.
+
+## Heading and Tone Pattern
+
+- Use section titles that feel like a real Korean tech blog.
+- Question-style headings are allowed when they improve readability.
+- Example heading patterns:
+  - `{기존 개념}?`
+  - `{도구}? 넌 누구냐`
+  - `동작 원리`
+  - `사용 방법`
+  - `주의점`
+- After each code block, explain in 1-3 sentences what the reader should notice.
+- Do not turn the whole article into bullet points; use bullets only for advantages, disadvantages, steps, or caution items.
+
+## Output Rules
+
+1. Title
+2. Introduction
+3. Body
+   - Concept explanation
+   - Example
+   - Advantages
+   - Disadvantages
+   - Related technologies or real-world uses
+4. Closing
+5. Consider SEO-friendly subheadings when useful
+
+## Guardrails
+
+- Do not change the core meaning of the source note.
+- Do not force extra detail when the source is thin.
+- Output must be Tistory-ready Markdown.
+
+## Output Structure
+
+```md
+# {흥미를 끄는 제목}
+
+{주제를 쉽게 소개하는 도입부 2~4문단}
+
+## {기존 방식 또는 배경 개념}
+{먼저 알아야 할 개념 설명}
+
+### 대표적인 예시
+{기존 방식이 왜 불편한지 보여주는 쉬운 예시 설명}
+
+### 장점
+- ...
+- ...
+
+### 단점
+- ...
+- ...
+
+## {해결책이 되는 개념 또는 라이브러리}
+{왜 이 도구가 등장했는지 설명}
+
+### 대표적인 예시
+{개선된 사용 예시 설명}
+
+### 장점
+- ...
+- ...
+
+### 단점
+- ...
+- ...
+
+## 동작 원리
+{핵심 함수, 내부 방식, 주요 개념 설명}
+
+## 사용 방법
+### 1. 설치
+```bash
+# 설치 명령
+```
+
+### 2. 기본 사용 예시
+{가장 기본적인 사용 방식 설명}
+
+```language
+// 코드 예제
+```
+
+### 3. 실무 활용 예시
+{React, 상태 관리, 실전 적용 예시}
+
+## 주의점
+- ...
+- ...
+
+## 관련 기술 / 심화 개념
+{연결되는 기술이나 실무 활용 예시 설명}
+
+### 핵심 요약
+- ...
+- ...
+
+## 마무리
+{핵심 요약과 마무리 문단}
+```


### PR DESCRIPTION
## 변경 내용 요약
- 노션 소스를 블로그 초안과 링크드인 초안으로 변환하는 CLI 워크플로우를 추가했습니다.
- Codex handoff 모드와 OpenAI API 모드를 모두 지원하도록 블로그 초안 생성 흐름을 구성했습니다.
- 환경 변수 예시, 사용 템플릿, 로컬 Codex skill, README, `.gitignore`를 함께 정리했습니다.

## 변경 이유
- 노션 기반 콘텐츠 초안 작성과 재게시 과정을 반복 실행 가능한 스크립트로 묶기 위해서입니다.
- 소스 선택 방식을 URL, 페이지 ID, 페이지 경로, 데이터베이스 필터까지 넓혀 운영 유연성을 확보하려는 목적입니다.

## 주요 변경 사항
- `npm run create-blog`가 노션 소스를 가져오고 `output/create-blog.md`까지 이어지는 블로그 초안 흐름을 제공합니다.
- `npm run create-linkedin`, `npm run publish-linkedin`, `npm run publish-blog-draft`로 초안 저장 및 노션 게시 단계를 지원합니다.
- `npm run list-notion-tree`로 페이지 경로 탐색을 지원하고, 템플릿/문서/skill 파일로 사용 흐름을 정리했습니다.

## 테스트 방법
- `npm run check`
